### PR TITLE
[FIX][SC-40682] Keyboard navigation for month year picker

### DIFF
--- a/src/month.jsx
+++ b/src/month.jsx
@@ -363,17 +363,18 @@ export default class Month extends React.Component {
       setPreSelection,
     } = this.props;
     const eventKey = event.key;
-    const monthColumnsLayout = getMonthColumnsLayout(
-      showFourColumnMonthYearPicker,
-      showTwoColumnMonthYearPicker
-    );
-    const verticalOffset =
-      MONTH_COLUMNS[monthColumnsLayout].verticalNavigationOffset;
     if (eventKey !== "Tab") {
       // preventDefault on tab event blocks focus change
       event.preventDefault();
     }
     if (!disabledKeyboardNavigation) {
+      const monthColumnsLayout = getMonthColumnsLayout(
+        showFourColumnMonthYearPicker,
+        showTwoColumnMonthYearPicker
+      );
+      const verticalOffset =
+        MONTH_COLUMNS[monthColumnsLayout].verticalNavigationOffset;
+      const monthsGrid = MONTH_COLUMNS[monthColumnsLayout].grid;
       switch (eventKey) {
         case "Enter":
           this.onMonthClick(event, month);
@@ -393,7 +394,8 @@ export default class Month extends React.Component {
           break;
         case "ArrowUp":
           this.handleMonthNavigation(
-            month >= 0 && month <= 2
+            // Check if month on the first row
+            monthsGrid[0].includes(month)
               ? month + 12 - verticalOffset
               : month - verticalOffset,
             utils.subMonths(preSelection, verticalOffset)
@@ -401,7 +403,8 @@ export default class Month extends React.Component {
           break;
         case "ArrowDown":
           this.handleMonthNavigation(
-            month >= 9 && month <= 11
+            // Check if month on the last row
+            monthsGrid[monthsGrid.length - 1].includes(month)
               ? month - 12 + verticalOffset
               : month + verticalOffset,
             utils.addMonths(preSelection, verticalOffset)

--- a/test/month_test.js
+++ b/test/month_test.js
@@ -639,96 +639,541 @@ describe("Month", () => {
   });
 
   describe("Keyboard navigation", () => {
+    context("monthsFourColumns", () => {
+      const renderMonth = (props) =>
+        mount(
+          <Month showMonthYearPicker showFourColumnMonthYearPicker {...props} />
+        );
+
+      it("should trigger setPreSelection and set March as pre-selected on arrowRight", () => {
+        let preSelected = false;
+        const setPreSelection = (param) => {
+          preSelected = param;
+        };
+
+        const monthComponent = renderMonth({
+          selected: utils.newDate("2015-02-01"),
+          day: utils.newDate("2015-02-01"),
+          setPreSelection: setPreSelection,
+          preSelection: utils.newDate("2015-02-01"),
+        });
+        monthComponent
+          .find(".react-datepicker__month-1")
+          .simulate("keydown", getKey("Tab"));
+        monthComponent
+          .find(".react-datepicker__month-1")
+          .simulate("keydown", getKey("ArrowRight"));
+
+        expect(preSelected.toString()).to.equal(
+          utils.newDate("2015-03-01").toString()
+        );
+      });
+
+      it("should trigger setPreSelection and set January as pre-selected on arrowLeft", () => {
+        let preSelected = false;
+        const setPreSelection = (param) => {
+          preSelected = param;
+        };
+        const monthComponent = renderMonth({
+          selected: utils.newDate("2015-02-01"),
+          day: utils.newDate("2015-02-01"),
+          setPreSelection: setPreSelection,
+          preSelection: utils.newDate("2015-02-01"),
+        });
+        monthComponent
+          .find(".react-datepicker__month-1")
+          .simulate("keydown", getKey("ArrowLeft"));
+
+        expect(preSelected.toString()).to.equal(
+          utils.newDate("2015-01-01").toString()
+        );
+      });
+
+      it("should trigger setPreSelection and set April as pre-selected on arrowUp", () => {
+        let preSelected = false;
+        const setPreSelection = (param) => {
+          preSelected = param;
+        };
+
+        const monthComponent = renderMonth({
+          selected: utils.newDate("2015-08-01"),
+          day: utils.newDate("2015-08-01"),
+          setPreSelection: setPreSelection,
+          preSelection: utils.newDate("2015-08-01"),
+        });
+
+        monthComponent
+          .find(".react-datepicker__month-7")
+          .simulate("keydown", getKey("ArrowUp"));
+
+        expect(preSelected.toString()).to.equal(
+          utils.newDate("2015-04-01").toString()
+        );
+      });
+
+      it("should trigger setPreSelection and set December as pre-selected on arrowDown", () => {
+        let preSelected = false;
+        const setPreSelection = (param) => {
+          preSelected = param;
+        };
+
+        const monthComponent = renderMonth({
+          selected: utils.newDate("2015-08-01"),
+          day: utils.newDate("2015-08-01"),
+          setPreSelection: setPreSelection,
+          preSelection: utils.newDate("2015-08-01"),
+        });
+
+        monthComponent
+          .find(".react-datepicker__month-7")
+          .simulate("keydown", getKey("ArrowDown"));
+
+        expect(preSelected.toString()).to.equal(
+          utils.newDate("2015-12-01").toString()
+        );
+      });
+
+      it("should pre-select January of next year on arrowRight", () => {
+        let preSelected = false;
+        const setPreSelection = (param) => {
+          preSelected = param;
+        };
+
+        const monthComponent = renderMonth({
+          selected: utils.newDate("2015-12-01"),
+          day: utils.newDate("2015-12-01"),
+          setPreSelection: setPreSelection,
+          preSelection: utils.newDate("2015-12-01"),
+        });
+
+        monthComponent
+          .find(".react-datepicker__month-11")
+          .simulate("keydown", getKey("ArrowRight"));
+        expect(preSelected.toString()).to.equal(
+          utils.newDate("2016-01-01").toString()
+        );
+      });
+
+      it("should pre-select December of previous year on arrowLeft", () => {
+        let preSelected = false;
+        const setPreSelection = (param) => {
+          preSelected = param;
+        };
+
+        const monthComponent = renderMonth({
+          selected: utils.newDate("2015-01-01"),
+          day: utils.newDate("2015-01-01"),
+          setPreSelection: setPreSelection,
+          preSelection: utils.newDate("2015-01-01"),
+        });
+
+        monthComponent
+          .find(".react-datepicker__month-0")
+          .simulate("keydown", getKey("ArrowLeft"));
+        expect(preSelected.toString()).to.equal(
+          utils.newDate("2014-12-01").toString()
+        );
+      });
+
+      it("should pre-select October of previous year on arrowUp", () => {
+        let preSelected = false;
+        const setPreSelection = (param) => {
+          preSelected = param;
+        };
+
+        const monthComponent = renderMonth({
+          selected: utils.newDate("2015-02-01"),
+          day: utils.newDate("2015-02-01"),
+          setPreSelection: setPreSelection,
+          preSelection: utils.newDate("2015-02-01"),
+        });
+
+        monthComponent
+          .find(".react-datepicker__month-1")
+          .simulate("keydown", getKey("ArrowUp"));
+        expect(preSelected.toString()).to.equal(
+          utils.newDate("2014-10-01").toString()
+        );
+      });
+
+      it("should pre-select March of next year on arrowDown", () => {
+        let preSelected = false;
+        const setPreSelection = (param) => {
+          preSelected = param;
+        };
+
+        const monthComponent = renderMonth({
+          selected: utils.newDate("2015-11-01"),
+          day: utils.newDate("2015-11-01"),
+          setPreSelection: setPreSelection,
+          preSelection: utils.newDate("2015-11-01"),
+        });
+
+        monthComponent
+          .find(".react-datepicker__month-10")
+          .simulate("keydown", getKey("ArrowDown"));
+        expect(preSelected.toString()).to.equal(
+          utils.newDate("2016-03-01").toString()
+        );
+      });
+    });
+    context("monthsThreeColumns", () => {
+      const renderMonth = (props) =>
+        mount(<Month showMonthYearPicker {...props} />);
+
+      it("should trigger setPreSelection and set March as pre-selected on arrowRight", () => {
+        let preSelected = false;
+        const setPreSelection = (param) => {
+          preSelected = param;
+        };
+
+        const monthComponent = renderMonth({
+          selected: utils.newDate("2015-02-01"),
+          day: utils.newDate("2015-02-01"),
+          setPreSelection: setPreSelection,
+          preSelection: utils.newDate("2015-02-01"),
+        });
+        monthComponent
+          .find(".react-datepicker__month-1")
+          .simulate("keydown", getKey("Tab"));
+        monthComponent
+          .find(".react-datepicker__month-1")
+          .simulate("keydown", getKey("ArrowRight"));
+
+        expect(preSelected.toString()).to.equal(
+          utils.newDate("2015-03-01").toString()
+        );
+      });
+
+      it("should trigger setPreSelection and set January as pre-selected on arrowLeft", () => {
+        let preSelected = false;
+        const setPreSelection = (param) => {
+          preSelected = param;
+        };
+        const monthComponent = renderMonth({
+          selected: utils.newDate("2015-02-01"),
+          day: utils.newDate("2015-02-01"),
+          setPreSelection: setPreSelection,
+          preSelection: utils.newDate("2015-02-01"),
+        });
+        monthComponent
+          .find(".react-datepicker__month-1")
+          .simulate("keydown", getKey("ArrowLeft"));
+
+        expect(preSelected.toString()).to.equal(
+          utils.newDate("2015-01-01").toString()
+        );
+      });
+
+      it("should trigger setPreSelection and set May as pre-selected on arrowUp", () => {
+        let preSelected = false;
+        const setPreSelection = (param) => {
+          preSelected = param;
+        };
+
+        const monthComponent = renderMonth({
+          selected: utils.newDate("2015-08-01"),
+          day: utils.newDate("2015-08-01"),
+          setPreSelection: setPreSelection,
+          preSelection: utils.newDate("2015-08-01"),
+        });
+
+        monthComponent
+          .find(".react-datepicker__month-7")
+          .simulate("keydown", getKey("ArrowUp"));
+
+        expect(preSelected.toString()).to.equal(
+          utils.newDate("2015-05-01").toString()
+        );
+      });
+
+      it("should trigger setPreSelection and set November as pre-selected on arrowDown", () => {
+        let preSelected = false;
+        const setPreSelection = (param) => {
+          preSelected = param;
+        };
+
+        const monthComponent = renderMonth({
+          selected: utils.newDate("2015-08-01"),
+          day: utils.newDate("2015-08-01"),
+          setPreSelection: setPreSelection,
+          preSelection: utils.newDate("2015-08-01"),
+        });
+
+        monthComponent
+          .find(".react-datepicker__month-7")
+          .simulate("keydown", getKey("ArrowDown"));
+
+        expect(preSelected.toString()).to.equal(
+          utils.newDate("2015-11-01").toString()
+        );
+      });
+
+      it("should pre-select January of next year on arrowRight", () => {
+        let preSelected = false;
+        const setPreSelection = (param) => {
+          preSelected = param;
+        };
+
+        const monthComponent = renderMonth({
+          selected: utils.newDate("2015-12-01"),
+          day: utils.newDate("2015-12-01"),
+          setPreSelection: setPreSelection,
+          preSelection: utils.newDate("2015-12-01"),
+        });
+
+        monthComponent
+          .find(".react-datepicker__month-11")
+          .simulate("keydown", getKey("ArrowRight"));
+        expect(preSelected.toString()).to.equal(
+          utils.newDate("2016-01-01").toString()
+        );
+      });
+
+      it("should pre-select December of previous year on arrowLeft", () => {
+        let preSelected = false;
+        const setPreSelection = (param) => {
+          preSelected = param;
+        };
+
+        const monthComponent = renderMonth({
+          selected: utils.newDate("2015-01-01"),
+          day: utils.newDate("2015-01-01"),
+          setPreSelection: setPreSelection,
+          preSelection: utils.newDate("2015-01-01"),
+        });
+
+        monthComponent
+          .find(".react-datepicker__month-0")
+          .simulate("keydown", getKey("ArrowLeft"));
+        expect(preSelected.toString()).to.equal(
+          utils.newDate("2014-12-01").toString()
+        );
+      });
+
+      it("should pre-select November of previous year on arrowUp", () => {
+        let preSelected = false;
+        const setPreSelection = (param) => {
+          preSelected = param;
+        };
+
+        const monthComponent = renderMonth({
+          selected: utils.newDate("2015-02-01"),
+          day: utils.newDate("2015-02-01"),
+          setPreSelection: setPreSelection,
+          preSelection: utils.newDate("2015-02-01"),
+        });
+
+        monthComponent
+          .find(".react-datepicker__month-1")
+          .simulate("keydown", getKey("ArrowUp"));
+        expect(preSelected.toString()).to.equal(
+          utils.newDate("2014-11-01").toString()
+        );
+      });
+
+      it("should pre-select March of next year on arrowDown", () => {
+        let preSelected = false;
+        const setPreSelection = (param) => {
+          preSelected = param;
+        };
+
+        const monthComponent = renderMonth({
+          selected: utils.newDate("2015-11-01"),
+          day: utils.newDate("2015-11-01"),
+          setPreSelection: setPreSelection,
+          preSelection: utils.newDate("2015-11-01"),
+        });
+
+        monthComponent
+          .find(".react-datepicker__month-10")
+          .simulate("keydown", getKey("ArrowDown"));
+        expect(preSelected.toString()).to.equal(
+          utils.newDate("2016-02-01").toString()
+        );
+      });
+    });
+    context("monthsTwoColumns", () => {
+      const renderMonth = (props) =>
+        mount(
+          <Month showMonthYearPicker showTwoColumnMonthYearPicker {...props} />
+        );
+
+      it("should trigger setPreSelection and set March as pre-selected on arrowRight", () => {
+        let preSelected = false;
+        const setPreSelection = (param) => {
+          preSelected = param;
+        };
+
+        const monthComponent = renderMonth({
+          selected: utils.newDate("2015-02-01"),
+          day: utils.newDate("2015-02-01"),
+          setPreSelection: setPreSelection,
+          preSelection: utils.newDate("2015-02-01"),
+        });
+        monthComponent
+          .find(".react-datepicker__month-1")
+          .simulate("keydown", getKey("Tab"));
+        monthComponent
+          .find(".react-datepicker__month-1")
+          .simulate("keydown", getKey("ArrowRight"));
+
+        expect(preSelected.toString()).to.equal(
+          utils.newDate("2015-03-01").toString()
+        );
+      });
+
+      it("should trigger setPreSelection and set January as pre-selected on arrowLeft", () => {
+        let preSelected = false;
+        const setPreSelection = (param) => {
+          preSelected = param;
+        };
+        const monthComponent = renderMonth({
+          selected: utils.newDate("2015-02-01"),
+          day: utils.newDate("2015-02-01"),
+          setPreSelection: setPreSelection,
+          preSelection: utils.newDate("2015-02-01"),
+        });
+        monthComponent
+          .find(".react-datepicker__month-1")
+          .simulate("keydown", getKey("ArrowLeft"));
+
+        expect(preSelected.toString()).to.equal(
+          utils.newDate("2015-01-01").toString()
+        );
+      });
+
+      it("should trigger setPreSelection and set June as pre-selected on arrowUp", () => {
+        let preSelected = false;
+        const setPreSelection = (param) => {
+          preSelected = param;
+        };
+
+        const monthComponent = renderMonth({
+          selected: utils.newDate("2015-08-01"),
+          day: utils.newDate("2015-08-01"),
+          setPreSelection: setPreSelection,
+          preSelection: utils.newDate("2015-08-01"),
+        });
+
+        monthComponent
+          .find(".react-datepicker__month-7")
+          .simulate("keydown", getKey("ArrowUp"));
+
+        expect(preSelected.toString()).to.equal(
+          utils.newDate("2015-06-01").toString()
+        );
+      });
+
+      it("should trigger setPreSelection and set October as pre-selected on arrowDown", () => {
+        let preSelected = false;
+        const setPreSelection = (param) => {
+          preSelected = param;
+        };
+
+        const monthComponent = renderMonth({
+          selected: utils.newDate("2015-08-01"),
+          day: utils.newDate("2015-08-01"),
+          setPreSelection: setPreSelection,
+          preSelection: utils.newDate("2015-08-01"),
+        });
+
+        monthComponent
+          .find(".react-datepicker__month-7")
+          .simulate("keydown", getKey("ArrowDown"));
+
+        expect(preSelected.toString()).to.equal(
+          utils.newDate("2015-10-01").toString()
+        );
+      });
+
+      it("should pre-select January of next year on arrowRight", () => {
+        let preSelected = false;
+        const setPreSelection = (param) => {
+          preSelected = param;
+        };
+
+        const monthComponent = renderMonth({
+          selected: utils.newDate("2015-12-01"),
+          day: utils.newDate("2015-12-01"),
+          setPreSelection: setPreSelection,
+          preSelection: utils.newDate("2015-12-01"),
+        });
+
+        monthComponent
+          .find(".react-datepicker__month-11")
+          .simulate("keydown", getKey("ArrowRight"));
+        expect(preSelected.toString()).to.equal(
+          utils.newDate("2016-01-01").toString()
+        );
+      });
+
+      it("should pre-select December of previous year on arrowLeft", () => {
+        let preSelected = false;
+        const setPreSelection = (param) => {
+          preSelected = param;
+        };
+
+        const monthComponent = renderMonth({
+          selected: utils.newDate("2015-01-01"),
+          day: utils.newDate("2015-01-01"),
+          setPreSelection: setPreSelection,
+          preSelection: utils.newDate("2015-01-01"),
+        });
+
+        monthComponent
+          .find(".react-datepicker__month-0")
+          .simulate("keydown", getKey("ArrowLeft"));
+        expect(preSelected.toString()).to.equal(
+          utils.newDate("2014-12-01").toString()
+        );
+      });
+
+      it("should pre-select November of previous year on arrowUp", () => {
+        let preSelected = false;
+        const setPreSelection = (param) => {
+          preSelected = param;
+        };
+
+        const monthComponent = renderMonth({
+          selected: utils.newDate("2015-01-01"),
+          day: utils.newDate("2015-01-01"),
+          setPreSelection: setPreSelection,
+          preSelection: utils.newDate("2015-01-01"),
+        });
+
+        monthComponent
+          .find(".react-datepicker__month-0")
+          .simulate("keydown", getKey("ArrowUp"));
+        expect(preSelected.toString()).to.equal(
+          utils.newDate("2014-11-01").toString()
+        );
+      });
+
+      it("should pre-select January of next year on arrowDown", () => {
+        let preSelected = false;
+        const setPreSelection = (param) => {
+          preSelected = param;
+        };
+
+        const monthComponent = renderMonth({
+          selected: utils.newDate("2015-11-01"),
+          day: utils.newDate("2015-11-01"),
+          setPreSelection: setPreSelection,
+          preSelection: utils.newDate("2015-11-01"),
+        });
+
+        monthComponent
+          .find(".react-datepicker__month-10")
+          .simulate("keydown", getKey("ArrowDown"));
+        expect(preSelected.toString()).to.equal(
+          utils.newDate("2016-01-01").toString()
+        );
+      });
+    });
+
     const renderMonth = (props) =>
       mount(<Month showMonthYearPicker {...props} />);
-
-    it("should trigger setPreSelection and set March as pre-selected on arrowRight", () => {
-      let preSelected = false;
-      const setPreSelection = (param) => {
-        preSelected = param;
-      };
-
-      const monthComponent = renderMonth({
-        selected: utils.newDate("2015-02-01"),
-        day: utils.newDate("2015-02-01"),
-        setPreSelection: setPreSelection,
-        preSelection: utils.newDate("2015-02-01"),
-      });
-      monthComponent
-        .find(".react-datepicker__month-1")
-        .simulate("keydown", getKey("Tab"));
-      monthComponent
-        .find(".react-datepicker__month-1")
-        .simulate("keydown", getKey("ArrowRight"));
-
-      expect(preSelected.toString()).to.equal(
-        utils.newDate("2015-03-01").toString()
-      );
-    });
-
-    it("should trigger setPreSelection and set January as pre-selected on arrowLeft", () => {
-      let preSelected = false;
-      const setPreSelection = (param) => {
-        preSelected = param;
-      };
-      const monthComponent = renderMonth({
-        selected: utils.newDate("2015-02-01"),
-        day: utils.newDate("2015-02-01"),
-        setPreSelection: setPreSelection,
-        preSelection: utils.newDate("2015-02-01"),
-      });
-      monthComponent
-        .find(".react-datepicker__month-1")
-        .simulate("keydown", getKey("ArrowLeft"));
-
-      expect(preSelected.toString()).to.equal(
-        utils.newDate("2015-01-01").toString()
-      );
-    });
-
-    it("should trigger setPreSelection and set May as pre-selected on arrowUp", () => {
-      let preSelected = false;
-      const setPreSelection = (param) => {
-        preSelected = param;
-      };
-
-      const monthComponent = renderMonth({
-        selected: utils.newDate("2015-08-01"),
-        day: utils.newDate("2015-08-01"),
-        setPreSelection: setPreSelection,
-        preSelection: utils.newDate("2015-08-01"),
-      });
-
-      monthComponent
-        .find(".react-datepicker__month-1")
-        .simulate("keydown", getKey("ArrowUp"));
-
-      expect(preSelected.toString()).to.equal(
-        utils.newDate("2015-05-01").toString()
-      );
-    });
-
-    it("should trigger setPreSelection and set Nov as pre-selected on arrowDown", () => {
-      let preSelected = false;
-      const setPreSelection = (param) => {
-        preSelected = param;
-      };
-
-      const monthComponent = renderMonth({
-        selected: utils.newDate("2015-08-01"),
-        day: utils.newDate("2015-08-01"),
-        setPreSelection: setPreSelection,
-        preSelection: utils.newDate("2015-08-01"),
-      });
-
-      monthComponent
-        .find(".react-datepicker__month-1")
-        .simulate("keydown", getKey("ArrowDown"));
-
-      expect(preSelected.toString()).to.equal(
-        utils.newDate("2015-11-01").toString()
-      );
-    });
 
     it("should select March when Enter is pressed", () => {
       let preSelected = false;
@@ -758,90 +1203,6 @@ describe("Month", () => {
       expect(preSelected).to.equal(true);
       expect(selectedDate.toString()).to.equal(
         utils.newDate("2015-03-01").toString()
-      );
-    });
-
-    it("should pre-select Jan of next year on arrowRight", () => {
-      let preSelected = false;
-      const setPreSelection = (param) => {
-        preSelected = param;
-      };
-
-      const monthComponent = renderMonth({
-        selected: utils.newDate("2015-12-01"),
-        day: utils.newDate("2015-12-01"),
-        setPreSelection: setPreSelection,
-        preSelection: utils.newDate("2015-12-01"),
-      });
-
-      monthComponent
-        .find(".react-datepicker__month-11")
-        .simulate("keydown", getKey("ArrowRight"));
-      expect(preSelected.toString()).to.equal(
-        utils.newDate("2016-01-01").toString()
-      );
-    });
-
-    it("should pre-select Dec of previous year on arrowLeft", () => {
-      let preSelected = false;
-      const setPreSelection = (param) => {
-        preSelected = param;
-      };
-
-      const monthComponent = renderMonth({
-        selected: utils.newDate("2015-01-01"),
-        day: utils.newDate("2015-01-01"),
-        setPreSelection: setPreSelection,
-        preSelection: utils.newDate("2015-01-01"),
-      });
-
-      monthComponent
-        .find(".react-datepicker__month-0")
-        .simulate("keydown", getKey("ArrowLeft"));
-      expect(preSelected.toString()).to.equal(
-        utils.newDate("2014-12-01").toString()
-      );
-    });
-
-    it("should pre-select Nov of previous year on arrowUp", () => {
-      let preSelected = false;
-      const setPreSelection = (param) => {
-        preSelected = param;
-      };
-
-      const monthComponent = renderMonth({
-        selected: utils.newDate("2015-02-01"),
-        day: utils.newDate("2015-02-01"),
-        setPreSelection: setPreSelection,
-        preSelection: utils.newDate("2015-02-01"),
-      });
-
-      monthComponent
-        .find(".react-datepicker__month-11")
-        .simulate("keydown", getKey("ArrowUp"));
-      expect(preSelected.toString()).to.equal(
-        utils.newDate("2014-11-01").toString()
-      );
-    });
-
-    it("should pre-select March of next year on arrowDown", () => {
-      let preSelected = false;
-      const setPreSelection = (param) => {
-        preSelected = param;
-      };
-
-      const monthComponent = renderMonth({
-        selected: utils.newDate("2015-11-01"),
-        day: utils.newDate("2015-11-01"),
-        setPreSelection: setPreSelection,
-        preSelection: utils.newDate("2015-11-01"),
-      });
-
-      monthComponent
-        .find(".react-datepicker__month-11")
-        .simulate("keydown", getKey("ArrowDown"));
-      expect(preSelected.toString()).to.equal(
-        utils.newDate("2016-02-01").toString()
       );
     });
 


### PR DESCRIPTION
Vertical keyboard navigation (Up & Down) was wrong for 4 and 2 months columns layout

(Internal) Associated shortcut story: [sc-40682](https://app.shortcut.com/opendatasoft/story/40682/dateinput-fix-keyboard-navigation-for-month-calendar)

Associated issue: https://github.com/Hacker0x01/react-datepicker/issues/3927


