### PR TITLE
[FEATURE][SC-40667] Add range modifiers for year calendar

### DIFF
--- a/docs-site/src/components/Examples/index.js
+++ b/docs-site/src/components/Examples/index.js
@@ -75,7 +75,6 @@ import RenderCustomDay from "../../examples/renderCustomDay";
 import TimeInput from "../../examples/timeInput";
 import StrictParsing from "../../examples/strictParsing";
 import MonthPicker from "../../examples/monthPicker";
-import YearPicker from "../../examples/yearPicker";
 import monthPickerFullName from "../../examples/monthPickerFullName";
 import monthPickerTwoColumns from "../../examples/monthPickerTwoColumns";
 import monthPickerFourColumns from "../../examples/monthPickerFourColumns";
@@ -84,6 +83,9 @@ import RangeMonthPickerSelectsRange from "../../examples/rangeMonthPickerSelects
 import QuarterPicker from "../../examples/quarterPicker";
 import RangeQuarterPicker from "../../examples/rangeQuarterPicker";
 import RangeQuarterPickerSelectsRange from "../../examples/rangeQuarterPickerSelectsRange";
+import YearPicker from "../../examples/yearPicker";
+import RangeYearPicker from "../../examples/rangeYearPicker";
+import RangeYearPickerSelectsRange from "../../examples/rangeYearPickerSelectsRange";
 import OnCalendarChangeStateCallbacks from "../../examples/onCalendarOpenStateCallbacks";
 import CustomTimeInput from "../../examples/customTimeInput";
 import CloseOnScroll from "../../examples/closeOnScroll";
@@ -455,6 +457,14 @@ export default class exampleComponents extends React.Component {
     {
       title: "Year Picker",
       component: YearPicker,
+    },
+    {
+      title: "Range Year Picker",
+      component: RangeYearPicker,
+    },
+    {
+      title: "Range Year Picker for one datepicker",
+      component: RangeYearPickerSelectsRange,
     },
     {
       title: "Year dropdown",

--- a/docs-site/src/examples/rangeYearPicker.js
+++ b/docs-site/src/examples/rangeYearPicker.js
@@ -1,0 +1,26 @@
+() => {
+  const [startDate, setStartDate] = useState(new Date("2014/02/08"));
+  const [endDate, setEndDate] = useState(new Date("2024/04/08"));
+  return (
+    <>
+      <DatePicker
+        selected={startDate}
+        onChange={(date) => setStartDate(date)}
+        selectsStart
+        startDate={startDate}
+        endDate={endDate}
+        dateFormat="yyyy"
+        showYearPicker
+      />
+      <DatePicker
+        selected={endDate}
+        onChange={(date) => setEndDate(date)}
+        selectsEnd
+        startDate={startDate}
+        endDate={endDate}
+        dateFormat="yyyy"
+        showYearPicker
+      />
+    </>
+  );
+};

--- a/docs-site/src/examples/rangeYearPickerSelectsRange.js
+++ b/docs-site/src/examples/rangeYearPickerSelectsRange.js
@@ -1,0 +1,21 @@
+() => {
+  const [startDate, setStartDate] = useState(new Date("2014/02/08"));
+  const [endDate, setEndDate] = useState(null);
+
+  const handleChange = ([newStartDate, newEndDate]) => {
+    setStartDate(newStartDate);
+    setEndDate(newEndDate);
+  };
+
+  return (
+    <DatePicker
+      selected={startDate}
+      onChange={handleChange}
+      selectsRange
+      startDate={startDate}
+      endDate={endDate}
+      dateFormat="yyyy"
+      showYearPicker
+    />
+  );
+};

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,6 +78,8 @@
 | `onKeyDown`                  | `func`                         | `() {}`            |             |
 | `onMonthChange`              | `func`                         | `() {}`            |             |
 | `onMonthMouseLeave`          | `func`                         |                    |             |
+| `onYearMouseEnter`           | `func`                         |                    |             |
+| `onYearMouseLeave`           | `func`                         |                    |             |
 | `onSelect`                   | `func`                         | `() {}`            |             |
 | `onWeekSelect`               | `func`                         |                    |             |
 | `onYearChange`               | `func`                         | `() {}`            |             |

--- a/src/calendar.jsx
+++ b/src/calendar.jsx
@@ -192,6 +192,8 @@ export default class Calendar extends React.Component {
     renderDayContents: PropTypes.func,
     onDayMouseEnter: PropTypes.func,
     onMonthMouseLeave: PropTypes.func,
+    onYearMouseEnter: PropTypes.func,
+    onYearMouseLeave: PropTypes.func,
     showPopperArrow: PropTypes.bool,
     handleOnKeyDown: PropTypes.func,
     handleOnDayKeyDown: PropTypes.func,
@@ -309,6 +311,15 @@ export default class Calendar extends React.Component {
   handleMonthMouseLeave = () => {
     this.setState({ selectingDate: null });
     this.props.onMonthMouseLeave && this.props.onMonthMouseLeave();
+  };
+
+  handleYearMouseEnter = (event, year) => {
+    this.setState({ selectingDate: setYear(newDate(), year) });
+    !!this.props.onYearMouseEnter && this.props.onYearMouseEnter(event, year);
+  };
+
+  handleYearMouseLeave = (event, year) => {
+    !!this.props.onYearMouseLeave && this.props.onYearMouseLeave(event, year);
   };
 
   handleYearChange = (date) => {
@@ -435,6 +446,10 @@ export default class Calendar extends React.Component {
       }),
       () => this.handleYearChange(this.state.date)
     );
+  };
+
+  clearSelectingDate = () => {
+    this.setState({ selectingDate: null });
   };
 
   renderPreviousButton = () => {
@@ -927,8 +942,12 @@ export default class Calendar extends React.Component {
           {this.renderHeader()}
           <Year
             onDayClick={this.handleDayClick}
+            selectingDate={this.state.selectingDate}
+            clearSelectingDate={this.clearSelectingDate}
             date={this.state.date}
             {...this.props}
+            onYearMouseEnter={this.handleYearMouseEnter}
+            onYearMouseLeave={this.handleYearMouseLeave}
           />
         </div>
       );

--- a/src/date_utils.js
+++ b/src/date_utils.js
@@ -507,6 +507,20 @@ export function isQuarterDisabled(
   );
 }
 
+/**
+ * @param {number} year
+ * @param {date} start
+ * @param {date} end
+ * @returns {boolean}
+ */
+export function isYearInRange(year, start, end) {
+  if (!isValidDate(start) || !isValidDate(end)) return false;
+  const startYear = getYear(start);
+  const endYear = getYear(end);
+
+  return startYear <= year && endYear >= year;
+}
+
 export function isYearDisabled(
   year,
   { minDate, maxDate, excludeDates, includeDates, filterDate } = {}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -286,6 +286,8 @@ export default class DatePicker extends React.Component {
     focusSelectedMonth: PropTypes.bool,
     onDayMouseEnter: PropTypes.func,
     onMonthMouseLeave: PropTypes.func,
+    onYearMouseEnter: PropTypes.func,
+    onYearMouseLeave: PropTypes.func,
     showPopperArrow: PropTypes.bool,
     excludeScrollbar: PropTypes.bool,
     enableTabLoop: PropTypes.bool,
@@ -1010,6 +1012,8 @@ export default class DatePicker extends React.Component {
         renderDayContents={this.props.renderDayContents}
         onDayMouseEnter={this.props.onDayMouseEnter}
         onMonthMouseLeave={this.props.onMonthMouseLeave}
+        onYearMouseEnter={this.props.onYearMouseEnter}
+        onYearMouseLeave={this.props.onYearMouseLeave}
         selectsDisabledDaysInRange={this.props.selectsDisabledDaysInRange}
         showTimeInput={this.props.showTimeInput}
         showMonthYearPicker={this.props.showMonthYearPicker}

--- a/src/month.jsx
+++ b/src/month.jsx
@@ -201,6 +201,38 @@ export default class Month extends React.Component {
     return false;
   };
 
+  isSelectingMonthRangeStart = (m) => {
+    if (!this.isInSelectingRangeMonth(m)) {
+      return false;
+    }
+
+    const { day, startDate, selectsStart } = this.props;
+    const _month = utils.setMonth(day, m);
+    const selectingDate = this.props.selectingDate ?? this.props.preSelection;
+
+    if (selectsStart) {
+      return utils.isSameMonth(_month, selectingDate);
+    } else {
+      return utils.isSameMonth(_month, startDate);
+    }
+  };
+
+  isSelectingMonthRangeEnd = (m) => {
+    if (!this.isInSelectingRangeMonth(m)) {
+      return false;
+    }
+
+    const { day, endDate, selectsEnd, selectsRange } = this.props;
+    const _month = utils.setMonth(day, m);
+    const selectingDate = this.props.selectingDate ?? this.props.preSelection;
+
+    if (selectsEnd || selectsRange) {
+      return utils.isSameMonth(_month, selectingDate);
+    } else {
+      return utils.isSameMonth(_month, endDate);
+    }
+  };
+
   isInSelectingRangeQuarter = (q) => {
     const { day, selectsStart, selectsEnd, selectsRange, startDate, endDate } =
       this.props;
@@ -501,6 +533,10 @@ export default class Month extends React.Component {
         ),
         "react-datepicker__month-text--range-start": this.isRangeStartMonth(m),
         "react-datepicker__month-text--range-end": this.isRangeEndMonth(m),
+        "react-datepicker__month-text--selecting-range-start":
+          this.isSelectingMonthRangeStart(m),
+        "react-datepicker__month-text--selecting-range-end":
+          this.isSelectingMonthRangeEnd(m),
         "react-datepicker__month-text--today": this.isCurrentMonth(day, m),
       }
     );

--- a/src/stylesheets/datepicker.scss
+++ b/src/stylesheets/datepicker.scss
@@ -456,7 +456,8 @@
   }
 
   &--in-range:not(&--in-selecting-range) {
-    .react-datepicker__month--selecting-range & {
+    .react-datepicker__month--selecting-range &,
+    .react-datepicker__year--selecting-range & {
       background-color: $datepicker__background-color;
       color: $datepicker__text-color;
     }

--- a/src/year.jsx
+++ b/src/year.jsx
@@ -6,8 +6,10 @@ import classnames from "classnames";
 
 export default class Year extends React.Component {
   static propTypes = {
-    date: PropTypes.string,
+    clearSelectingDate: PropTypes.func,
+    date: PropTypes.instanceOf(Date),
     disabledKeyboardNavigation: PropTypes.bool,
+    endDate: PropTypes.instanceOf(Date),
     onDayClick: PropTypes.func,
     preSelection: PropTypes.instanceOf(Date),
     setPreSelection: PropTypes.func,
@@ -15,6 +17,13 @@ export default class Year extends React.Component {
     inline: PropTypes.bool,
     maxDate: PropTypes.instanceOf(Date),
     minDate: PropTypes.instanceOf(Date),
+    onYearMouseEnter: PropTypes.func.isRequired,
+    onYearMouseLeave: PropTypes.func.isRequired,
+    selectingDate: PropTypes.instanceOf(Date),
+    selectsEnd: PropTypes.bool,
+    selectsStart: PropTypes.bool,
+    selectsRange: PropTypes.bool,
+    startDate: PropTypes.instanceOf(Date),
     excludeDates: PropTypes.array,
     includeDates: PropTypes.array,
     filterDate: PropTypes.func,
@@ -32,6 +41,8 @@ export default class Year extends React.Component {
   isDisabled = (date) => utils.isDayDisabled(date, this.props);
 
   isExcluded = (date) => utils.isDayExcluded(date, this.props);
+
+  selectingDate = () => this.props.selectingDate ?? this.props.preSelection;
 
   updateFocusOnPaginate = (refIndex) => {
     const waitForReRender = function () {
@@ -64,6 +75,69 @@ export default class Year extends React.Component {
   isSameDay = (y, other) => utils.isSameDay(y, other);
 
   isCurrentYear = (y) => y === getYear(newDate());
+
+  isRangeStart = (y) =>
+    this.props.startDate &&
+    this.props.endDate &&
+    utils.isSameYear(utils.setYear(newDate(), y), this.props.startDate);
+
+  isRangeEnd = (y) =>
+    this.props.startDate &&
+    this.props.endDate &&
+    utils.isSameYear(utils.setYear(newDate(), y), this.props.endDate);
+
+  isInRange = (y) =>
+    utils.isYearInRange(y, this.props.startDate, this.props.endDate);
+
+  isInSelectingRange = (y) => {
+    const { selectsStart, selectsEnd, selectsRange, startDate, endDate } =
+      this.props;
+
+    if (
+      !(selectsStart || selectsEnd || selectsRange) ||
+      !this.selectingDate()
+    ) {
+      return false;
+    }
+    if (selectsStart && endDate) {
+      return utils.isYearInRange(y, this.selectingDate(), endDate);
+    }
+    if (selectsEnd && startDate) {
+      return utils.isYearInRange(y, startDate, this.selectingDate());
+    }
+    if (selectsRange && startDate && !endDate) {
+      return utils.isYearInRange(y, startDate, this.selectingDate());
+    }
+    return false;
+  };
+
+  isSelectingRangeStart = (y) => {
+    if (!this.isInSelectingRange(y)) {
+      return false;
+    }
+
+    const { startDate, selectsStart } = this.props;
+    const _year = utils.setYear(newDate(), y);
+
+    if (selectsStart) {
+      return utils.isSameYear(_year, this.selectingDate());
+    }
+    return utils.isSameYear(_year, startDate);
+  };
+
+  isSelectingRangeEnd = (y) => {
+    if (!this.isInSelectingRange(y)) {
+      return false;
+    }
+
+    const { endDate, selectsEnd, selectsRange } = this.props;
+    const _year = utils.setYear(newDate(), y);
+
+    if (selectsEnd || selectsRange) {
+      return utils.isSameYear(_year, this.selectingDate());
+    }
+    return utils.isSameYear(_year, endDate);
+  };
 
   isKeyboardSelected = (y) => {
     const date = utils.getStartOfYear(utils.setYear(this.props.date, y));
@@ -120,6 +194,15 @@ export default class Year extends React.Component {
         utils.isYearDisabled(y, this.props),
       "react-datepicker__year-text--keyboard-selected":
         this.isKeyboardSelected(y),
+      "react-datepicker__year-text--range-start": this.isRangeStart(y),
+      "react-datepicker__year-text--range-end": this.isRangeEnd(y),
+      "react-datepicker__year-text--in-range": this.isInRange(y),
+      "react-datepicker__year-text--in-selecting-range":
+        this.isInSelectingRange(y),
+      "react-datepicker__year-text--selecting-range-start":
+        this.isSelectingRangeStart(y),
+      "react-datepicker__year-text--selecting-range-end":
+        this.isSelectingRangeEnd(y),
       "react-datepicker__year-text--today": this.isCurrentYear(y),
     });
   };
@@ -131,9 +214,19 @@ export default class Year extends React.Component {
     return y === preSelected ? "0" : "-1";
   };
 
+  getYearContainerClassNames = () => {
+    const { selectingDate, selectsStart, selectsEnd, selectsRange } =
+      this.props;
+    return classnames("react-datepicker__year", {
+      "react-datepicker__year--selecting-range":
+        selectingDate && (selectsStart || selectsEnd || selectsRange),
+    });
+  };
+
   render() {
     const yearsList = [];
-    const { date, yearItemNumber } = this.props;
+    const { date, yearItemNumber, onYearMouseEnter, onYearMouseLeave } =
+      this.props;
     const { startPeriod, endPeriod } = utils.getYearsPeriod(
       date,
       yearItemNumber
@@ -151,6 +244,8 @@ export default class Year extends React.Component {
           }}
           tabIndex={this.getYearTabIndex(y)}
           className={this.getYearClassNames(y)}
+          onMouseEnter={(ev) => onYearMouseEnter(ev, y)}
+          onMouseLeave={(ev) => onYearMouseLeave(ev, y)}
           key={y}
           aria-current={this.isCurrentYear(y) ? "date" : undefined}
         >
@@ -160,8 +255,13 @@ export default class Year extends React.Component {
     }
 
     return (
-      <div className="react-datepicker__year">
-        <div className="react-datepicker__year-wrapper">{yearsList}</div>
+      <div className={this.getYearContainerClassNames()}>
+        <div
+          className="react-datepicker__year-wrapper"
+          onMouseLeave={this.props.clearSelectingDate}
+        >
+          {yearsList}
+        </div>
       </div>
     );
   }

--- a/test/date_utils_test.js
+++ b/test/date_utils_test.js
@@ -27,6 +27,7 @@ import {
   parseDate,
   isMonthinRange,
   isQuarterInRange,
+  isYearInRange,
   getStartOfYear,
   getYearsPeriod,
   setDefaultLocale,
@@ -1011,6 +1012,30 @@ describe("date_utils", function () {
       const endDate = newDate("2020-02-01");
 
       expect(isQuarterInRange(startDate, endDate, 5, day)).to.be.true;
+    });
+  });
+
+  describe("isYearInRange", () => {
+    it("should return true if the year passed is in range", () => {
+      const startDate = newDate("2000-01-01");
+      const endDate = newDate("2015-08-01");
+      // Check start range
+      expect(isYearInRange(2000, startDate, endDate)).to.be.true;
+      // Check end range
+      expect(isYearInRange(2015, startDate, endDate)).to.be.true;
+      expect(isYearInRange(2010, startDate, endDate)).to.be.true;
+    });
+
+    it("should return false if the year passed is not in range", () => {
+      const startDate = newDate("2000-01-01");
+      const endDate = newDate("2015-08-01");
+
+      expect(isYearInRange(1999, startDate, endDate)).to.be.false;
+      expect(isYearInRange(2016, startDate, endDate)).to.be.false;
+    });
+
+    it("should return false if range isn't passed", () => {
+      expect(isYearInRange(2016)).to.be.false;
     });
   });
 

--- a/test/datepicker_test.js
+++ b/test/datepicker_test.js
@@ -2113,4 +2113,41 @@ describe("DatePicker", () => {
     ).getAttribute("class");
     expect(showIconClass).to.equal("react-datepicker__calendar-icon");
   });
+
+  describe("Year picker", () => {
+    it("should call onYearMouseEnter and onYearMouseEnter", (done) => {
+      const onYearMouseEnterSpy = sandbox.spy();
+      const onYearMouseLeaveSpy = sandbox.spy();
+      const datePicker = mount(
+        <DatePicker
+          selected={new Date(2023, 0, 1)}
+          showYearPicker
+          onYearMouseEnter={onYearMouseEnterSpy}
+          onYearMouseLeave={onYearMouseLeaveSpy}
+        />
+      );
+
+      const dateInputWrapper = datePicker.find("input");
+      dateInputWrapper.simulate("click");
+      const calendarWrapper = datePicker.find("Calendar");
+      const selectedYear = calendarWrapper.find(
+        ".react-datepicker__year-text--selected"
+      );
+
+      selectedYear.simulate("mouseenter");
+      selectedYear.simulate("mouseleave");
+
+      defer(() => {
+        assert(
+          onYearMouseEnterSpy.called === true,
+          "should call DatePicker onYearMouseEnter"
+        );
+        assert(
+          onYearMouseLeaveSpy.called === true,
+          "should call DatePicker onYearMouseLeave"
+        );
+        done();
+      });
+    });
+  });
 });

--- a/test/month_test.js
+++ b/test/month_test.js
@@ -413,6 +413,43 @@ describe("Month", () => {
 
       expect(months.length).to.equal(0);
     });
+
+    it("should add 'selecting-range-start' class to the start selecting month", () => {
+      const monthComponent = mount(
+        <Month
+          preSelection={utils.newDate("2015-01-01")}
+          day={utils.newDate("2015-01-01")}
+          endDate={utils.newDate("2015-03-01")}
+          selectingDate={utils.newDate("2015-02-01")}
+          selectsStart
+          showMonthYearPicker
+        />
+      );
+      const months = monthComponent.find(
+        ".react-datepicker__month-text--selecting-range-start"
+      );
+      expect(months.length).to.equal(1);
+      expect(months.at(0).text()).to.eq("Feb");
+    });
+
+    it("should add 'selecting-range-end' class to the end selecting month", () => {
+      const monthComponent = mount(
+        <Month
+          preSelection={utils.newDate("2015-01-01")}
+          day={utils.newDate("2015-01-01")}
+          startDate={utils.newDate("2015-01-01")}
+          endDate={utils.newDate("2015-03-01")}
+          selectingDate={utils.newDate("2015-06-01")}
+          selectsEnd
+          showMonthYearPicker
+        />
+      );
+      const months = monthComponent.find(
+        ".react-datepicker__month-text--selecting-range-end"
+      );
+      expect(months.length).to.equal(1);
+      expect(months.at(0).text()).to.eq("Jun");
+    });
   });
 
   describe("selecting quarter range", () => {

--- a/test/year_picker_test.js
+++ b/test/year_picker_test.js
@@ -199,6 +199,236 @@ describe("YearPicker", () => {
     }
   });
 
+  describe("range", () => {
+    it("should add range classes", () => {
+      const yearComponent = mount(
+        <Year
+          date={utils.newDate("2009-01-01")}
+          startDate={utils.newDate("2009-01-01")}
+          endDate={utils.newDate("2012-01-01")}
+        />
+      );
+
+      const inRangeYears = yearComponent.find(
+        ".react-datepicker__year-text--in-range"
+      );
+
+      expect(inRangeYears.length).to.equal(4);
+      expect(inRangeYears.at(0).text()).to.eq("2009");
+      expect(inRangeYears.at(1).text()).to.eq("2010");
+      expect(inRangeYears.at(2).text()).to.eq("2011");
+      expect(inRangeYears.at(3).text()).to.eq("2012");
+
+      const rangeStartYear = yearComponent.find(
+        ".react-datepicker__year-text--range-start"
+      );
+
+      expect(rangeStartYear.length).to.equal(1);
+      expect(rangeStartYear.at(0).text()).to.eq("2009");
+
+      const rangeEndYear = yearComponent.find(
+        ".react-datepicker__year-text--range-end"
+      );
+
+      expect(rangeEndYear.length).to.equal(1);
+      expect(rangeEndYear.at(0).text()).to.eq("2012");
+    });
+
+    it("should not add range classes when start date is not defined", () => {
+      const yearComponent = mount(
+        <Year
+          date={utils.newDate("2009-01-01")}
+          endDate={utils.newDate("2012-01-01")}
+        />
+      );
+
+      const inRangeYears = yearComponent.find(
+        ".react-datepicker__year-text--in-range"
+      );
+      const rangeStartYear = yearComponent.find(
+        ".react-datepicker__year-text--range-start"
+      );
+      const rangeEndYear = yearComponent.find(
+        ".react-datepicker__year-text--range-end"
+      );
+
+      expect(inRangeYears.length).to.equal(0);
+      expect(rangeEndYear.length).to.equal(0);
+      expect(rangeStartYear.length).to.equal(0);
+    });
+
+    it("should not add range classes when end date is not defined", () => {
+      const yearComponent = mount(
+        <Year
+          date={utils.newDate("2009-01-01")}
+          startDate={utils.newDate("2009-01-01")}
+        />
+      );
+
+      const inRangeYears = yearComponent.find(
+        ".react-datepicker__year-text--in-range"
+      );
+      const rangeStartYear = yearComponent.find(
+        ".react-datepicker__year-text--range-start"
+      );
+      const rangeEndYear = yearComponent.find(
+        ".react-datepicker__year-text--range-end"
+      );
+
+      expect(inRangeYears.length).to.equal(0);
+      expect(rangeEndYear.length).to.equal(0);
+      expect(rangeStartYear.length).to.equal(0);
+    });
+
+    describe("selecting", () => {
+      it("should add in-selecting-range class if year is between the selecting date and end date", () => {
+        const yearComponent = mount(
+          <Year
+            preSelection={utils.newDate("2015-01-01")}
+            date={utils.newDate("2012-01-01")}
+            endDate={utils.newDate("2016-01-01")}
+            selectingDate={utils.newDate("2015-01-01")}
+            selectsStart
+          />
+        );
+
+        const years = yearComponent.find(
+          ".react-datepicker__year-text--in-selecting-range"
+        );
+
+        expect(years.length).to.equal(2);
+        expect(years.at(0).text()).to.eq("2015");
+        expect(years.at(1).text()).to.eq("2016");
+      });
+
+      it("should add in-selecting-range class if year is between the start date and selecting date", () => {
+        const yearComponent = mount(
+          <Year
+            preSelection={utils.newDate("2011-01-01")}
+            date={utils.newDate("2015-01-01")}
+            startDate={utils.newDate("2010-01-01")}
+            selectingDate={utils.newDate("2011-01-01")}
+            selectsEnd
+          />
+        );
+
+        const years = yearComponent.find(
+          ".react-datepicker__year-text--in-selecting-range"
+        );
+
+        expect(years.length).to.equal(2);
+        expect(years.at(0).text()).to.eq("2010");
+        expect(years.at(1).text()).to.eq("2011");
+      });
+
+      it("should use pre selection date if selecting date is not defined", () => {
+        const yearComponent = mount(
+          <Year
+            preSelection={utils.newDate("2011-01-01")}
+            date={utils.newDate("2015-01-01")}
+            startDate={utils.newDate("2010-01-01")}
+            selectsEnd
+          />
+        );
+
+        const years = yearComponent.find(
+          ".react-datepicker__year-text--in-selecting-range"
+        );
+
+        expect(years.length).to.equal(2);
+        expect(years.at(0).text()).to.eq("2010");
+        expect(years.at(1).text()).to.eq("2011");
+      });
+
+      it("should add in-selecting-range class for one year picker if year is between the start date and selecting date", () => {
+        const yearComponent = mount(
+          <Year
+            preSelection={utils.newDate("2011-01-01")}
+            date={utils.newDate("2015-01-01")}
+            startDate={utils.newDate("2010-02-01")}
+            selectingDate={utils.newDate("2011-01-01")}
+            selectsRange
+          />
+        );
+        const years = yearComponent.find(
+          ".react-datepicker__year-text--in-selecting-range"
+        );
+
+        expect(years.length).to.equal(2);
+        expect(years.at(0).text()).to.eq("2010");
+        expect(years.at(1).text()).to.eq("2011");
+      });
+
+      it("should not add in-selecting-range class for one year picker if the start date is not defined", () => {
+        const yearComponent = mount(
+          <Year
+            preSelection={utils.newDate("2014-01-01")}
+            date={utils.newDate("2015-01-01")}
+            selectingDate={utils.newDate("2014-01-01")}
+            selectsRange
+          />
+        );
+        const years = yearComponent.find(
+          ".react-datepicker__year-text--in-selecting-range"
+        );
+
+        expect(years.length).to.equal(0);
+      });
+
+      it("should not add in-selecting-range class for one year picker if the end date is defined", () => {
+        const yearComponent = mount(
+          <Year
+            preSelection={utils.newDate("2014-01-01")}
+            date={utils.newDate("2013-01-01")}
+            selectingDate={utils.newDate("2014-01-01")}
+            endDate={utils.newDate("2013-01-01")}
+            selectsRange
+          />
+        );
+        const years = yearComponent.find(
+          ".react-datepicker__month-text--in-selecting-range"
+        );
+
+        expect(years.length).to.equal(0);
+      });
+
+      it("should add 'selecting-range-start' class to the start selecting year", () => {
+        const yearComponent = mount(
+          <Year
+            preSelection={utils.newDate("2012-01-01")}
+            date={utils.newDate("2010-01-01")}
+            endDate={utils.newDate("2015-01-01")}
+            selectingDate={utils.newDate("2012-01-01")}
+            selectsStart
+          />
+        );
+        const years = yearComponent.find(
+          ".react-datepicker__year-text--selecting-range-start"
+        );
+        expect(years.length).to.equal(1);
+        expect(years.at(0).text()).to.eq("2012");
+      });
+
+      it("should add 'selecting-range-end' class to the end selecting year", () => {
+        const yearComponent = mount(
+          <Year
+            preSelection={utils.newDate("2014-01-01")}
+            date={utils.newDate("2012-01-01")}
+            startDate={utils.newDate("2010-01-01")}
+            endDate={utils.newDate("2015-01-01")}
+            selectingDate={utils.newDate("2014-01-01")}
+            selectsEnd
+          />
+        );
+        const years = yearComponent.find(
+          ".react-datepicker__year-text--selecting-range-end"
+        );
+        expect(years.length).to.equal(1);
+        expect(years.at(0).text()).to.eq("2014");
+      });
+    });
+  });
+
   describe("keyboard-selected", () => {
     const className = "react-datepicker__year-text--keyboard-selected";
 


### PR DESCRIPTION
- Add missing range modifiers (`--selecting-range-start`, `--selecting-range-end`) for month calendar
- Add range modifiers for year calendar
   - Which made it possible to expose `onYearMouseEnter` `onYearMouseLeave` as props
   
   
   
   

https://github.com/opendatasoft/react-datepicker/assets/117300300/00587d71-6e4b-4d82-86f5-803904eef809


 Internal: [SC-40667](https://app.shortcut.com/opendatasoft/story/40667/)
 
 related issues:
 - https://github.com/Hacker0x01/react-datepicker/issues/4048
 - https://github.com/Hacker0x01/react-datepicker/issues/2719